### PR TITLE
Don't change behavior of goog.require if there is no dot

### DIFF
--- a/lib/nclosurebase.js
+++ b/lib/nclosurebase.js
@@ -1,4 +1,3 @@
-
 /**
  * @fileoverview This does 3 tasks.  It firstly detects sets up 2 interception
  * points intended for goog.js (or anyone else) to be notified of scripts
@@ -126,10 +125,7 @@ nclosure.base.prototype.interceptGoogRequires_ = function() {
     // If anyone is the using goog.require() for these types its only
     // to get a bit of compiler support
     else if (namespace.indexOf('nclosure_') === 0) { return; }
-    // Assume no namespace == node.js core libs
-    else if (namespace.indexOf('.') < 0) {
-      global[namespace] = nodeRequire(namespace);
-    } else {
+    else {
       googRequire(namespace);
     }
   };


### PR DESCRIPTION
The assumption to ignore goog.require behavior if there is no dot notation in the argument is very strange. It's very valid to goog.provide('example') and it should be possible to goog.require('example') too.
