### PR TITLE
fix deps cli invocation when args are supplied

### DIFF
--- a/lib/nclosurebase.js
+++ b/lib/nclosurebase.js
@@ -315,7 +315,7 @@ nclosure.base.prototype.loadDependenciesFile = function(dir, file) {
   * @private
   */
 nclosure.base.prototype.loadCurrentScriptDeps_ = function() {
-  var file = process.argv[process.argv.length - 1];
+  var file = process.argv[1];
   if (require('path').existsSync(file)) {
     var depsPath = !file ? null : this.settingsLoader_.getFileDirectory(file);
     if (depsPath) this.loadDependenciesFile(depsPath, 'deps.js');


### PR DESCRIPTION
loadCurrentScriptDeps_ obtains the current script being executed through:
var file = process.argv[process.argv.length - 1];
it then uses the directory where this file is contained to load the deps.js file.
If command line arguments are passed to the script (eg. node script.js -l) then deps.js will not be loaded since process.argv.length - 1 is -l
