### PR TITLE
Update path.existsSync to fs.existsSync

### DIFF
--- a/bin/nccompile.js
+++ b/bin/nccompile.js
@@ -202,10 +202,10 @@ nclosure.nccompile.prototype.runCompilation_ = function() {
  */
 nclosure.nccompile.prototype.onExit_ =
     function(err) {
-  if (require('path').existsSync(this.tmpFileName_)) {
+  if (require('fs').existsSync(this.tmpFileName_)) {
     require('fs').unlinkSync(this.tmpFileName_);
   }
-  if (require('path').existsSync(this.fileToCompileIgnore_)) {
+  if (require('fs').existsSync(this.fileToCompileIgnore_)) {
     require('fs').renameSync(this.fileToCompileIgnore_, this.fileToCompile_);
   }
   if (err) { console.error(err.stack); }

--- a/bin/nodetestsrunner.js
+++ b/bin/nodetestsrunner.js
@@ -97,7 +97,7 @@ nclosure.NodeTestsRunner.prototype.runNextTestImpl_ = function(file) {
   cmd.stdout.on('data', ondata);
   cmd.on('exit', function(code) {    
     var report = '';
-    if (require('path').existsSync(reportFile)) {
+    if (require('fs').existsSync(reportFile)) {
       report = fs.readFileSync(reportFile).toString();
       fs.unlinkSync(reportFile);
     }

--- a/lib/nclosurebase.js
+++ b/lib/nclosurebase.js
@@ -302,7 +302,7 @@ nclosure.base.prototype.loadScript = function(dir, file) {
   */
 nclosure.base.prototype.loadDependenciesFile = function(dir, file) {
   var path = this.settingsLoader_.getPath(dir, file);
-  if (!require('path').existsSync(path)) { return; }
+  if (!require('fs').existsSync(path)) { return; }
   this.loadScript(dir, file);
 };
 
@@ -316,7 +316,7 @@ nclosure.base.prototype.loadDependenciesFile = function(dir, file) {
   */
 nclosure.base.prototype.loadCurrentScriptDeps_ = function() {
   var file = process.argv[process.argv.length - 1];
-  if (require('path').existsSync(file)) {
+  if (require('fs').existsSync(file)) {
     var depsPath = !file ? null : this.settingsLoader_.getFileDirectory(file);
     if (depsPath) this.loadDependenciesFile(depsPath, 'deps.js');
   }

--- a/lib/settingsloader.js
+++ b/lib/settingsloader.js
@@ -59,7 +59,7 @@ nclosure.settingsLoader.prototype.getPath = function(baseDir, file) {
  * @return {string} The correctly directory of the specified file.
  */
 nclosure.settingsLoader.prototype.getFileDirectory = function(file) {
-  if (require('path').existsSync(file) &&
+  if (require('fs').existsSync(file) &&
       require('fs').statSync(file).isDirectory()) return file;
 
   var didx = file.search(/[\/\\][^\/\\]*$/g);
@@ -99,7 +99,7 @@ nclosure.settingsLoader.prototype.parseCompilerArgsFromFile = function(file) {
  * @return {nclosure.opts?} The settings object.
  */
 nclosure.settingsLoader.prototype.readArgsFromJSONFile = function(path) {
-  if (!path || !require('path').existsSync(path)) return null;
+  if (!path || !require('fs').existsSync(path)) return null;
   var json = require('fs').readFileSync(path).toString();  
   var lastSlash = path.search(/[\/\\][^\/\\]*$/g);
   var dir = path.substring(0, lastSlash);  
@@ -327,7 +327,7 @@ nclosure.settingsLoader.prototype.validateDir_ =
  * @return {boolean} Wether the specified directory exists.
  */
 nclosure.settingsLoader.prototype.checkDirExists_ = function(dir) {
-  return require('path').existsSync(dir);
+  return require('fs').existsSync(dir);
 };
 
 

--- a/lib/third_party/node/node.fs.js
+++ b/lib/third_party/node/node.fs.js
@@ -684,6 +684,28 @@ node.fs.createWriteStream = function(path, options) {
   return node.fs.core_.createWriteStream.apply(node.fs.core_, arguments);
 };
 
+/**
+ * Test whether or not the given path exists.  Then, call the <code>callback</code> argument
+ * with either true or false. Example:
+ * <pre>
+ *     fs.exists('&#47;etc&#47;passwd', function (exists) {
+ *       util.debug(exists ? "it's there" : "no passwd!");
+ *     });
+ * </pre>
+ * @param {string} path
+ * @param {function(Error?,...[*]):undefined=} callback
+ */
+node.fs.exists = function(path, callback) {
+  return node.fs.core_.exists.apply(node.fs.core_, arguments);
+};
+
+/**
+ * Synchronous version of <code>fs.exists</code>.
+ * @param {string} path
+ */
+node.fs.existsSync = function(path) {
+  return node.fs.core_.existsSync.apply(node.fs.core_, arguments);
+};
 
 /**
  * @private

--- a/lib/third_party/node/node.path.js
+++ b/lib/third_party/node/node.path.js
@@ -139,30 +139,6 @@ node.path.extname = function(path) {
 };
 
 /**
- * Test whether or not the given path exists.  Then, call the <code>callback</code> argument
- * with either true or false. Example:
- * <pre>
- *     path.exists('&#47;etc&#47;passwd', function (exists) {
- *       util.debug(exists ? "it's there" : "no passwd!");
- *     });
- * </pre>
- * @param {string} path
- * @param {function(Error?,...[*]):undefined=} callback
- */
-node.path.exists = function(path, callback) {
-  return node.path.core_.exists.apply(node.path.core_, arguments);
-};
-
-/**
- * Synchronous version of <code>path.exists</code>.
- * @param {string} path
- */
-node.path.existsSync = function(path) {
-  return node.path.core_.existsSync.apply(node.path.core_, arguments);
-};
-
-
-/**
  * @private
  * @type {*}
  */

--- a/lib/updatedeps.js
+++ b/lib/updatedeps.js
@@ -166,10 +166,10 @@ nclosure.updatedeps.prototype.runCommand_ = function(command, callback) {
  * @return {string} The new tmp directory
  */
 nclosure.updatedeps.prototype.moveDirToTmp_ = function(dir, callback) {
-  if (!require('path').existsSync(dir)) { return; }
+  if (!require('fs').existsSync(dir)) { return; }
 
   var tmp = dir + '.tmp';
-  if (require('path').existsSync(tmp)) {
+  if (require('fs').existsSync(tmp)) {
     require('child_process').exec('rm -rf ' + tmp, function() {
       require('fs').renameSync(dir, tmp);
       callback();
@@ -192,7 +192,7 @@ nclosure.updatedeps.prototype.moveDirToTmp_ = function(dir, callback) {
 nclosure.updatedeps.prototype.revertDirMove_ = function(dir, callback) {
   var untmp = dir.replace('.tmp', '');
   var that = this;
-  if (require('path').existsSync(untmp)) {
+  if (require('fs').existsSync(untmp)) {
     require('child_process').exec('rm -rf ' + untmp, function() {
       that.revertDirMoveImpl_(dir, untmp, callback);
     });

--- a/tests/docFrameworkTests.js
+++ b/tests/docFrameworkTests.js
@@ -8,7 +8,6 @@
 var ng_ = require('nclosure').nclosure();
 
 var fs_ = require('fs');
-var path_ = require('path');
 var testDir;
 var googDoc;
 
@@ -57,7 +56,7 @@ function assertClassInIndex(files) {
 };
 
 function writeOutFile(file, contents) {
-  if (!path_.existsSync(testDir)) { fs_.mkdirSync(testDir, 0777); }
+  if (!fs_.existsSync(testDir)) { fs_.mkdirSync(testDir, 0777); }
   var path = ng_.getPath(testDir, file)
   fs_.writeFileSync(path, contents.join('\n'), encoding = 'utf8');
 };
@@ -80,7 +79,7 @@ function getDirectory() {
 };
 
 function clearDir(callback) {
-  if (!testDir || !path_.existsSync(testDir)) {
+  if (!testDir || !fs_.existsSync(testDir)) {
     if (callback) callback();
     return
   }

--- a/tests/runClosureLibraryJSUnitsManual.js
+++ b/tests/runClosureLibraryJSUnitsManual.js
@@ -12,7 +12,6 @@ goog.require('goog.testing.jsunit');
 goog.require('nclosure.tests');
 
 var fs_ = require('fs');
-var path_ = require('path');
 
 var allTestFiles;
 var tmpdir = ng_.getPath(process.cwd(), 'tests/tmpclosuretests/');
@@ -67,7 +66,7 @@ function copyAndParseAllTestFiles(oncomplete) {
     if (err) return oncomplete(err);
     copyAndParseAllTestFilesImpl(oncomplete)
   };
-  if (path_.existsSync(tmpdir)) {
+  if (fs_.existsSync(tmpdir)) {
     nclosure.tests.rmRfDir(tmpdir, function(err) {
       if (err) return oncomplete(err);
       fs_.mkdir(tmpdir, 0777, impl);

--- a/third_party/node-jsdoc-toolkit/app/run.js
+++ b/third_party/node-jsdoc-toolkit/app/run.js
@@ -162,7 +162,7 @@ IO = {
 		if (fileName == null) fileName = FilePath.fileName(inFile);
     inFile = path.normalize(inFile);
     outFile = path.normalize(outDir + "/" + fileName);
-    if (!path.existsSync(inFile)) {
+    if (!fs.existsSync(inFile)) {
       // Could not find file to copy, ignoring: ' + inFile
       // Should we log or safe to ignore?
       return;


### PR DESCRIPTION
The `path.exists` and `path.existsSync` functions are deprecated in favor of `fs.exists` and `fs.existsSync`.  Beginning with Node v0.8, calls to those `path` functions result in a warning but are redirected to `fs`.  Beginning with Node v0.11.15, calls to those `path` functions fail.

These changes will update all `existsSync` calls (I could not find any usages of `exists`) to use the `fs` module.  I also updated the annotations to move those functions from `path` to `fs`.  I would have liked to regenerate the HTML docs but I couldn't get the `ncdoc` command to work for me.