### PR TITLE
Remove calls to processing.binding('evals')

### DIFF
--- a/lib/gennode/gennode.js
+++ b/lib/gennode/gennode.js
@@ -89,7 +89,7 @@ nclosure.gennode.gennode.prototype.processJSFile_ = function(f) {
   var fileExports = {};
   ctx.exports = fileExports;
 
-  try { process.binding('evals').Script.runInNewContext(js, ctx, f); }
+  try { require('vm').runInNewContext(js, ctx, f); }
   catch (ex) { console.error('Not parsing: ' + f + ' ex: ' + ex.message); }
   this.processObject_(f, fileExports);
 };

--- a/lib/nclosurebase.js
+++ b/lib/nclosurebase.js
@@ -280,8 +280,7 @@ nclosure.base.prototype.loadScript = function(dir, file) {
   var contents = require('fs').readFileSync(path).toString();
   contents = this.settingsLoader_.removeShebang(contents);
   try {
-    process.binding('evals').NodeScript.
-        runInThisContext.call(global, contents, file);
+    require('vm').runInThisContext.call(global, contents, file);
   } catch (ex) {
     console.error('Could not goog.require("' + path + '")\n' + ex.stack);
     process.exit(1);

--- a/lib/settingsloader.js
+++ b/lib/settingsloader.js
@@ -207,7 +207,7 @@ nclosure.settingsLoader.prototype.parseCompilerArgsFromFileImpl_ =
     }
   };
   code = this.removeShebang(code);
-  try { process.binding('evals').Script.runInNewContext(code, ctx, file); }
+  try { require('vm').runInNewContext(code, ctx, file); }
   catch (e) {}
   var dirIdx = file.search(/[\/\\][^\/\\]*$/g);
   var dir = dirIdx < 0 ? '.' : file.substring(0, dirIdx);


### PR DESCRIPTION
 Updating calls to processing.binding('evals') to use require('vm') instead. The former is deprecated.


